### PR TITLE
chore: update repository URLs from communitybridge to linuxfoundation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,4 +10,4 @@ The following versions of the LFX EasyCLA Contributor Console are supported.
 
 ## Reporting a EasyCLA Contributor Console Vulnerability
 
-To report a security vulnerability, please file a BUG REPORT as a new [GitHub Issue](https://github.com/communitybridge/easycla-contributor-console/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc).
+To report a security vulnerability, please file a BUG REPORT as a new [GitHub Issue](https://github.com/linuxfoundation/easycla-contributor-console/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc).

--- a/dev.md
+++ b/dev.md
@@ -13,7 +13,7 @@
 1. Fork Project into your own repository (from the UI)
 1. Clone the project from forked repository (command line).
 1. Create `upstream` remote reference
-   - Example: `git remote add upstream git@github.com:communitybridge/easycla-contributor-console.git`.
+   - Example: `git remote add upstream git@github.com:linuxfoundation/easycla-contributor-console.git`.
    The first time Pull in the latest reference from the upstream
    - Example: `git fetch upstream`
    Rebase and fix any merge conflicts


### PR DESCRIPTION
Update GitHub repository references in documentation files to reflect the organization migration from communitybridge to linuxfoundation.

- Update SECURITY.md GitHub issue URL
- Update dev.md upstream remote example URL

Fixes: https://github.com/linuxfoundation/easycla/issues/4742

Generated with [Cursor](https://cursor.com/)